### PR TITLE
drawRect:withFont deprecation handling

### DIFF
--- a/Classes/UI/HSTextViewInternal.m
+++ b/Classes/UI/HSTextViewInternal.m
@@ -115,9 +115,16 @@
     [[[HSHelpStack instance] appearance] customizeTextView:self];
     if (displayPlaceHolder && placeholder && placeholderColor) {
         [placeholderColor set];
-        [placeholder drawInRect:CGRectMake(8.0f, 8.0f, self.frame.size.width - 16.0f, self.frame.size.height - 16.0f) withFont:self.font];
+        CGRect drawRect = CGRectMake(8.0f, 8.0f, self.frame.size.width - 16.0f, self.frame.size.height - 16.0f);
+        if (floor(NSFoundationVersionNumber) > NSFoundationVersionNumber_iOS_6_1) {
+            [placeholder drawInRect:drawRect  withAttributes: @{NSFontAttributeName: self.font}]; //first available iOS7
+        } else {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+            [placeholder drawInRect:drawRect withFont:self.font]; //deprecated iOS7
+#pragma clang diagnostic pop
+        }
     }
-}
 
 
 


### PR DESCRIPTION
This makes it so iOS7 code gets the correct message, and iOS6 gets the
correct message.

Additionally it suppresses the warning for the deprecated code for the
selection that is iOS6 and less only.

This shouldn't be a functional change at all, merely removes warnings/updates code for future proofing
