### PR TITLE
Fix HappyFoxGear init method declaration

### DIFF
--- a/Classes/Stacks/HappyFox/HSHappyFoxGear.m
+++ b/Classes/Stacks/HappyFox/HSHappyFoxGear.m
@@ -38,8 +38,7 @@
 
 @implementation HSHappyFoxGear
 
-- (id)initWithInstanceUrl:(NSString*) instanceUrl apiKey:(NSString *)api_key authoCode:(NSString *)auth_code priorityID: (NSString *)priority_ID categoryID: (NSString *) category_ID;
-{
+- (id)initWithInstanceUrl:(NSString*) instanceUrl apiKey:(NSString *)api_key authoCode:(NSString *)auth_code priorityID: (NSString *)priority_ID categoryID: (NSString *) category_ID{
     if ( (self = [super init]) ) {
         self.api_key = api_key;
         self.auth_code = auth_code;


### PR DESCRIPTION
Appears the method declaration was copied/pasted from header file.

Fixes:

```
(lldb) Objective-C stub for message `initWithInstanceUrl:apiKey:authoCode:priorityID:categoryID:' type `@@:@@@@@' not precompiled. Make sure you properly link with the framework or library that defines this message.
```
