### PR TITLE
Fix imports

### DIFF
--- a/Classes/Core/HSAppearance.h
+++ b/Classes/Core/HSAppearance.h
@@ -21,7 +21,7 @@
 //THE SOFTWARE.
 
 
-#import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
 
 @interface HSAppearance : NSObject
 

--- a/Classes/Core/HSAttachment.h
+++ b/Classes/Core/HSAttachment.h
@@ -20,7 +20,7 @@
 //OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //THE SOFTWARE.
 
-#import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
 
 /**
     `HSAttachment` class is used to hold ticket attachment information.

--- a/Classes/Stacks/Desk/HSDeskGear.m
+++ b/Classes/Stacks/Desk/HSDeskGear.m
@@ -24,7 +24,7 @@
 #import "HSDeskCase.h"
 #import <AFNetworking/AFHTTPRequestOperationManager.h>
 #import "UIImage+Extended.h"
-#import <AFNetworkActivityIndicatorManager.h>
+#import <AFNetworking/AFNetworkActivityIndicatorManager.h>
 
 @interface HSDeskGear ()
 

--- a/Classes/Stacks/HappyFox/HSHappyFoxGear.m
+++ b/Classes/Stacks/HappyFox/HSHappyFoxGear.m
@@ -23,7 +23,7 @@
 #import "HSHappyFoxGear.h"
 #import "HSAttachment.h"
 #import "UIImage+Extended.h"
-#import <AFNetworkActivityIndicatorManager.h>
+#import <AFNetworking/AFNetworkActivityIndicatorManager.h>
 
 @interface HSHappyFoxGear ()
 

--- a/Classes/Stacks/ZenDesk/HSZenDeskGear.m
+++ b/Classes/Stacks/ZenDesk/HSZenDeskGear.m
@@ -21,7 +21,7 @@
 //THE SOFTWARE.
 
 #import <AFNetworking/AFHTTPRequestOperationManager.h>
-#import <AFNetworkActivityIndicatorManager.h>
+#import <AFNetworking/AFNetworkActivityIndicatorManager.h>
 
 #import "HSZenDeskGear.h"
 #import "HSZenDeskTicket.h"


### PR DESCRIPTION
This simply fixes incorrect imports that prevent the code from compiling on a brand new Xcode project. (Apple changed the default setup for new Xcode projects related to imports and also removed the precompiled header). This PR allows the code to compile on a brand new Xcode project without any config changes. Thanks!