### PR TITLE
Handle image picker cancel

### DIFF
--- a/Classes/UI/HSNewIssueViewController.m
+++ b/Classes/UI/HSNewIssueViewController.m
@@ -454,4 +454,8 @@
     [assetslibrary assetForURL:imageURL resultBlock:resultblock failureBlock:nil];
 }
 
+- (void) imagePickerControllerDidCancel:(UIImagePickerController *)picker
+{
+	[self dismissViewControllerAnimated:YES completion:nil];
+}
 @end


### PR DESCRIPTION
When the user selects the picture attachment button and then cancel it the ViewController does not disappear.