### PR TITLE
Fix bug when select search bar on iPad

### DIFF
--- a/Resources/HelpStackStoryboard-iPad.storyboard
+++ b/Resources/HelpStackStoryboard-iPad.storyboard
@@ -41,6 +41,7 @@
                             </connections>
                         </barButtonItem>
                     </navigationItem>
+                    <modalFormSheetSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
                     <connections>
                         <outlet property="searchDisplayController" destination="xY8-yf-3xb" id="tJB-9D-L4i"/>
                         <segue destination="mSz-ZP-fGv" kind="push" identifier="MyIssueDetail" id="UtT-9D-aS4"/>


### PR DESCRIPTION
Fix the bug when selecting search bar on iPad 

It would go full screen and cover the status bar